### PR TITLE
User can add a payment type from profile page

### DIFF
--- a/BangazonSite/Controllers/PaymentTypesController.cs
+++ b/BangazonSite/Controllers/PaymentTypesController.cs
@@ -7,17 +7,26 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using BangazonSite.Data;
 using BangazonSite.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using System.Security.Claims;
 
 namespace BangazonSite.Controllers
 {
     public class PaymentTypesController : Controller
     {
         private readonly ApplicationDbContext _context;
+        private readonly UserManager<ApplicationUser> _userManager;
 
-        public PaymentTypesController(ApplicationDbContext context)
+        public PaymentTypesController(ApplicationDbContext context, UserManager<ApplicationUser> userManager)
         {
-            _context = context;    
+            _context = context;
+            _userManager = userManager;
         }
+
+        // Retrieve currently logged in user
+        private Task<ApplicationUser> GetCurrentUserAsync() => _userManager.GetUserAsync(HttpContext.User);
+
 
         // GET: PaymentTypes
         public async Task<IActionResult> Index()
@@ -44,23 +53,39 @@ namespace BangazonSite.Controllers
         }
 
         // GET: PaymentTypes/Create
-        public IActionResult Create()
+        // This method was authored by Jordan Dhaenens
+        public async Task<IActionResult> Create()
         {
-            return View();
+            PaymentType model = new PaymentType();
+           
+            // Get current user
+            var user = await GetCurrentUserAsync();
+            model.User = user;
+
+            return View(model);
         }
 
         // POST: PaymentTypes/Create
         // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
+        // This method was authored by Jordan Dhaenens
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("PaymentTypeId,Type,AccountNumber,IsActive")] PaymentType paymentType)
         {
+            ModelState.Remove("User");
+
             if (ModelState.IsValid)
             {
+                // Get current user
+                var user = await GetCurrentUserAsync();
+                paymentType.User = user;
+                paymentType.IsActive = true;
+
                 _context.Add(paymentType);
+
                 await _context.SaveChangesAsync();
-                return RedirectToAction("Index");
+                return RedirectToRoute(new { controller = "Manage", action = "Index" });
             }
             return View(paymentType);
         }

--- a/BangazonSite/Views/Manage/Index.cshtml
+++ b/BangazonSite/Views/Manage/Index.cshtml
@@ -67,5 +67,7 @@
                     </form>
                 }*@
         </dd>
+        <dt>Add Payment Option:</dt>
+        <dd><a asp-area="" asp-controller="PaymentTypes" asp-action="Create">Add Payment...</a></dd>
     </dl>
 </div>

--- a/BangazonSite/Views/PaymentTypes/Create.cshtml
+++ b/BangazonSite/Views/PaymentTypes/Create.cshtml
@@ -6,6 +6,7 @@
 
 <h2>Create</h2>
 
+<h3>@Model.User.FirstName, Enter your Payment Info:</h3>
 <form asp-action="Create">
     <div class="form-horizontal">
         <h4>PaymentType</h4>
@@ -25,14 +26,7 @@
                 <span asp-validation-for="AccountNumber" class="text-danger"></span>
             </div>
         </div>
-        <div class="form-group">
-            <div class="col-md-offset-2 col-md-10">
-                <div class="checkbox">
-                    <input asp-for="IsActive" />
-                    <label asp-for="IsActive"></label>
-                </div>
-            </div>
-        </div>
+        
         <div class="form-group">
             <div class="col-md-offset-2 col-md-10">
                 <input type="submit" value="Create" class="btn btn-default" />


### PR DESCRIPTION
## Status
Choose:
**READY**


## Description
User can add a payment type to their account from the profile page.

## Todos
- [x] Tests
- [ ] Documentation

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
1. git fetch
2. git checkout jd-AddPayment
3. Throw ```dotnet run``` in the terminal
4. Sign in, click on user in navbar, and follow the link on the profile page to add a payment type

## Impacted Areas in Application
List general components of the application that this PR will affect:
PaymentTypesController.cs
Manage views/ Index.cshtml
PaymentType view / Create.cshtml

## Link to Feature Ticket
#7
@ill-fated-ducks
