### PR TITLE
Jd delete payment

### DIFF
--- a/BangazonSite/Controllers/PaymentTypesController.cs
+++ b/BangazonSite/Controllers/PaymentTypesController.cs
@@ -31,7 +31,11 @@ namespace BangazonSite.Controllers
         // GET: PaymentTypes
         public async Task<IActionResult> Index()
         {
-            return View(await _context.PaymentType.ToListAsync());
+            // Get current user
+            var user = await GetCurrentUserAsync();
+
+            IEnumerable<PaymentType> models =  await _context.PaymentType.Where(p => p.User.Id == user.Id).ToListAsync();
+            return View(models);
         }
 
         // GET: PaymentTypes/Details/5
@@ -85,7 +89,7 @@ namespace BangazonSite.Controllers
                 _context.Add(paymentType);
 
                 await _context.SaveChangesAsync();
-                return RedirectToRoute(new { controller = "Manage", action = "Index" });
+                return RedirectToAction("Index");
             }
             return View(paymentType);
         }

--- a/BangazonSite/Data/SeedData.cs
+++ b/BangazonSite/Data/SeedData.cs
@@ -355,6 +355,29 @@ namespace BangazonSite.Data
                 );
                 context.SaveChanges();
             }
+
+            if (context.Order.Any())
+            {
+                // Already seeded
+            }
+            else
+            {
+                var userStore = new UserStore<ApplicationUser>(context);
+                context.Order.AddRange(
+                    new Order
+                    {
+                        User = userStore.Users.First<ApplicationUser>(u => u.UserName == "wakka@bangazon.com"),
+                        PaymentTypeId = 7
+                    },
+
+                    new Order
+                    {
+                        User = userStore.Users.First<ApplicationUser>(u => u.UserName == "wakka@bangazon.com"),
+                        PaymentTypeId = 7
+                    }
+                );
+                context.SaveChanges();
+            }
         }
 
     }

--- a/BangazonSite/Data/SeedData.cs
+++ b/BangazonSite/Data/SeedData.cs
@@ -367,13 +367,40 @@ namespace BangazonSite.Data
                     new Order
                     {
                         User = userStore.Users.First<ApplicationUser>(u => u.UserName == "wakka@bangazon.com"),
-                        PaymentTypeId = 7
+                        PaymentTypeId = 1
                     },
 
                     new Order
                     {
                         User = userStore.Users.First<ApplicationUser>(u => u.UserName == "wakka@bangazon.com"),
-                        PaymentTypeId = 7
+                        PaymentTypeId = 1
+                    }
+                );
+                context.SaveChanges();
+            }
+
+            if (context.PaymentType.Any())
+            {
+                // Already seeded
+            }
+            else
+            {
+                var userStore = new UserStore<ApplicationUser>(context);
+                context.PaymentType.AddRange(
+                    new PaymentType
+                    {
+                        User = userStore.Users.First<ApplicationUser>(u => u.UserName == "wakka@bangazon.com"),
+                        IsActive = true,
+                        AccountNumber = "1234123412341234",
+                        Type = "Outdoors"
+                    },
+
+                    new PaymentType
+                    {
+                        User = userStore.Users.First<ApplicationUser>(u => u.UserName == "wakka@bangazon.com"),
+                        IsActive = true,
+                        AccountNumber = "1234123412341234",
+                        Type = "Vida"
                     }
                 );
                 context.SaveChanges();

--- a/BangazonSite/Models/PaymentTypeViewModels/PaymentDeleteVM.cs
+++ b/BangazonSite/Models/PaymentTypeViewModels/PaymentDeleteVM.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BangazonSite.Models;
+using BangazonSite.Data;
+
+namespace BangazonSite.Models.PaymentTypeViewModels
+{
+    public class PaymentDeleteVM
+    {
+        public PaymentType PaymentType { get; set; }
+        public Order Order { get; set; }
+        public PaymentDeleteVM(ApplicationDbContext ctx, int id)
+        {
+            this.PaymentType = ctx.PaymentType.SingleOrDefault(m => m.PaymentTypeId == id);
+            this.Order = ctx.Order.FirstOrDefault(o => o.PaymentTypeId == id);
+        }
+    }
+}

--- a/BangazonSite/Views/Manage/Index.cshtml
+++ b/BangazonSite/Views/Manage/Index.cshtml
@@ -67,7 +67,7 @@
                     </form>
                 }*@
         </dd>
-        <dt>Add Payment Option:</dt>
-        <dd><a asp-area="" asp-controller="PaymentTypes" asp-action="Create">Add Payment...</a></dd>
+        <dt>Payment Options:</dt>
+        <dd><a asp-area="" asp-controller="PaymentTypes" asp-action="Index">Add Payment or Delete Payment Methods...</a></dd>
     </dl>
 </div>

--- a/BangazonSite/Views/PaymentTypes/Delete.cshtml
+++ b/BangazonSite/Views/PaymentTypes/Delete.cshtml
@@ -24,12 +24,6 @@
         <dd>
             @Html.DisplayFor(model => model.AccountNumber)
         </dd>
-        <dt>
-            @Html.DisplayNameFor(model => model.IsActive)
-        </dt>
-        <dd>
-            @Html.DisplayFor(model => model.IsActive)
-        </dd>
     </dl>
     
     <form asp-action="Delete">

--- a/BangazonSite/Views/PaymentTypes/Index.cshtml
+++ b/BangazonSite/Views/PaymentTypes/Index.cshtml
@@ -4,10 +4,10 @@
     ViewData["Title"] = "Index";
 }
 
-<h2>Index</h2>
+<h2>Welcome to the Payments Options, user</h2>
 
 <p>
-    <a asp-action="Create">Create New</a>
+    <a asp-action="Create">Add New Payment Type</a>
 </p>
 <table class="table">
     <thead>
@@ -17,9 +17,6 @@
                 </th>
                 <th>
                     @Html.DisplayNameFor(model => model.AccountNumber)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.IsActive)
                 </th>
             <th></th>
         </tr>
@@ -34,14 +31,17 @@
                 @Html.DisplayFor(modelItem => item.AccountNumber)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.IsActive)
-            </td>
-            <td>
-                <a asp-action="Edit" asp-route-id="@item.PaymentTypeId">Edit</a> |
-                <a asp-action="Details" asp-route-id="@item.PaymentTypeId">Details</a> |
                 <a asp-action="Delete" asp-route-id="@item.PaymentTypeId">Delete</a>
             </td>
         </tr>
 }
+        <tr>
+            <td><a asp-area="" asp-controller="Manage" asp-action="Index">Return to Profile Page</a></td>
+            <td></td>
+            <td></td>
+        </tr>
     </tbody>
 </table>
+
+
+


### PR DESCRIPTION
## Status
Choose:
**READY**


## Description
An authenticated user on the profile view can delete their payment types from account. If the payment type has never been used to complete an order then it is truly deleted from the database. Else, if the payment type has been used to complete an order then it marked as isActive = false and no longer shows up on their profile yet remains in the database.

## Todo
- [ ] Tests
- [ ] Documentation

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
1. git fetch
2. git checkout jd-deletePayment
3. Ensure that your PaymentTypes table in DB is empty (manually delete entries if necessary)
3. Type ```dotnet run``` in terminal 
4. Log with Username: wakka@bangazon.com Password: secret
5. go to profile page and click payment options
6. Delete Wakka's payment types through the app and then view the results in DB
7. Wakka's card with paymentTypeId 1 should still be in DB

## Impacted Areas in Application
SeedData.cs
PaymentDeleteVM.cs
PaymentTypesController.cs


## Link to Feature Ticket
#8
@ill-fated-ducks
